### PR TITLE
run ChipScan to get right result with change.

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -19,7 +19,7 @@ monitor_speed = 115200 ;Serial Baud Rate Setting
 upload_speed = 921600 ; 460800, 512000, 460800, 256000, 115200
 board_upload.flash_size = 16MB 
 
-board_build.memory_type = qio_opi ;Enable internal PSRAM
+board_build.arduino.memory_type = qio_opi ;Enable internal PSRAM
 ; board_build.memory_type = qio_qspi ;Enable external PSRAM
 
 board_build.partitions = default_16MB.csv 
@@ -29,7 +29,7 @@ build_flags =
     -Wextra ;somebody agree on
     ; -Werror ;Think of "Warning" as "Error".
     -D CORE_DEBUG_LEVEL=1 ;Debug level 0-5
-    ; -D BOARD_HAS_PSRAM ;Enable external PSRAM
+    -D BOARD_HAS_PSRAM ;Enable external PSRAM
     -D ARDUINO_USB_MODE=1
     -D ARDUINO_USB_CDC_ON_BOOT=1 ;1 is to use the USB port as a serial port
     -D ARDUINO_RUNNING_CORE=1       ; Arduino Runs On Core (setup, loop)
@@ -56,7 +56,7 @@ lib_dir = ./libraries
 ; default_envs = TFT
 
 src_dir = debug/examples/${platformio.default_envs}
-; default_envs = ChipScan
+default_envs = ChipScan
 ; default_envs = SD
 ; default_envs = SD_DMIC
 ; default_envs = IO
@@ -68,7 +68,7 @@ src_dir = debug/examples/${platformio.default_envs}
 ; default_envs = Wifi_STA_Contract
 ; default_envs = WIFI_HTTP_Download_File
 ; default_envs = FFat_Test
-default_envs = Music_Loop
+; default_envs = Music_Loop
 
 [env:DMIC_ReadData]
 [env:Wifi_Music]


### PR DESCRIPTION
board_build.memory_type changed to board_build.arduino.memory_type, it's right parameter to enable ChipScan sample to work to get PSRAM memory information.