### PR TITLE
fix: the esp32-audioi2s library authenticates agains... in Audio.cpp

### DIFF
--- a/libraries/ESP32-audioI2S-3.0.6/src/Audio.cpp
+++ b/libraries/ESP32-audioI2S-3.0.6/src/Audio.cpp
@@ -482,7 +482,7 @@ bool Audio::connecttohost(const char* host, const char* user, const char* pwd) {
     strcat(rqh, "\r\n");
     strcat(rqh, "Icy-MetaData:1\r\n");
 
-    if (auth > 0) {
+    if (auth > 0 && m_f_ssl) {
         strcat(rqh, "Authorization: Basic ");
         strcat(rqh, authorization);
         strcat(rqh, "\r\n");


### PR DESCRIPTION
## Summary
Fix high severity security issue in `libraries/ESP32-audioI2S-3.0.6/src/Audio.cpp`.

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | V-004 |
| **Severity** | HIGH |
| **Scanner** | multi_agent_ai |
| **Rule** | `V-004` |
| **File** | `libraries/ESP32-audioI2S-3.0.6/src/Audio.cpp:486` |

**Description**: The ESP32-audioI2S library authenticates against audio streaming servers using HTTP Basic Authentication over unencrypted HTTP. Basic Auth encodes credentials as Base64, which is trivially reversible and provides no encryption. Any device on the same Wi-Fi network can passively capture the HTTP request and decode the Authorization header to obtain the plaintext username and password. On embedded devices, these credentials are frequently hardcoded in firmware, meaning a single captured packet exposes credentials that cannot be easily rotated.

## Changes
- `libraries/ESP32-audioI2S-3.0.6/src/Audio.cpp`

## Verification
- [x] Build passes
- [x] Scanner re-scan confirms fix
- [x] LLM code review passed

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*
